### PR TITLE
Timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ If the type doesn't support printing then it will be shown as `?? unprintable ??
 
 ## Time outs
 
-By default the test runner will time out after 30 seconds. To increase this number define the pre-processor symbol `FELSPAR_TEST_RUNNER_TIMEOUT_SECONDS` to a higher (or, if you want, a smaller) number in your build configuration for the tests.
+The test runner has a watchdog which will kill the process (with exit code 127) if any single test runs for more than 30 seconds -- the deadline is reset after each test completes, so the limit applies per test rather than to the whole run. The time out message reports both how long the stuck test ran for and the total runtime of the test binary. To change the limit define the pre-processor symbol `FELSPAR_TEST_RUNNER_TIMEOUT_SECONDS` to a higher (or, if you want, a smaller) number in your build configuration for the tests.
 
 
 ## TODO

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -1,6 +1,7 @@
 #include <felspar/test/runner.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
@@ -42,6 +43,13 @@ std::string felspar::test::format_failure_message(
 
 
 namespace {
+    /**
+     * The point in time at which the watchdog will kill the process. Storing
+     * a new value extends (or shortens) the deadline -- the watchdog polls it
+     * every second rather than sleeping for the whole timeout.
+     */
+    std::atomic<std::chrono::steady_clock::time_point> deadline;
+
     inline std::string timestr(std::chrono::nanoseconds ns) {
         using namespace std::literals;
         if (ns < 1us) {
@@ -58,11 +66,16 @@ namespace {
 
 
 int main() {
-    std::thread{[]() {
-        constexpr std::chrono::seconds timeout{
-                FELSPAR_TEST_RUNNER_TIMEOUT_SECONDS};
-        std::this_thread::sleep_for(timeout);
-        std::cerr << "\n\nTiming out after " << timestr(timeout) << std::endl;
+    std::chrono::seconds constexpr timeout{FELSPAR_TEST_RUNNER_TIMEOUT_SECONDS};
+    auto const started = std::chrono::steady_clock::now();
+    deadline.store(started + timeout);
+    std::thread{[started]() {
+        while (std::chrono::steady_clock::now() < deadline.load()) {
+            std::this_thread::sleep_for(std::chrono::seconds{1});
+        }
+        std::cerr << "\n\nTiming out after "
+                  << timestr(std::chrono::steady_clock::now() - started)
+                  << std::endl;
         /**
          * A watchdog must terminate without running `atexit` handlers,
          * static destructors, or stream flushes. That ordered shutdown is

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -43,10 +43,13 @@ std::string felspar::test::format_failure_message(
 
 
 namespace {
+    std::chrono::seconds constexpr timeout{FELSPAR_TEST_RUNNER_TIMEOUT_SECONDS};
+
     /**
      * The point in time at which the watchdog will kill the process. Storing
      * a new value extends (or shortens) the deadline -- the watchdog polls it
-     * every second rather than sleeping for the whole timeout.
+     * every second rather than sleeping for the whole timeout. It is always
+     * set to `timeout` past the moment it was last reset.
      */
     std::atomic<std::chrono::steady_clock::time_point> deadline;
 
@@ -66,15 +69,16 @@ namespace {
 
 
 int main() {
-    std::chrono::seconds constexpr timeout{FELSPAR_TEST_RUNNER_TIMEOUT_SECONDS};
     auto const started = std::chrono::steady_clock::now();
     deadline.store(started + timeout);
     std::thread{[started]() {
         while (std::chrono::steady_clock::now() < deadline.load()) {
             std::this_thread::sleep_for(std::chrono::seconds{1});
         }
+        auto const now = std::chrono::steady_clock::now();
         std::cerr << "\n\nTiming out after "
-                  << timestr(std::chrono::steady_clock::now() - started)
+                  << timestr(now - deadline.load() + timeout)
+                  << " with total runtime " << timestr(now - started)
                   << std::endl;
         /**
          * A watchdog must terminate without running `atexit` handlers,

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -116,6 +116,7 @@ int main() {
             } catch (...) { std::cerr << "\nUnknown exception type"; }
         };
         std::cout << '\n';
+        deadline.store(std::chrono::steady_clock::now() + timeout);
     }
     std::cout << (pass + fail) << " tests run, " << pass << " passed";
     if (fail) {


### PR DESCRIPTION
Change the watch dog so that it counts the time out per test not per test runner.